### PR TITLE
Change dead URLs to git book

### DIFF
--- a/source/episodes/32-fugitive-vim-working-with-the-git-index.md
+++ b/source/episodes/32-fugitive-vim-working-with-the-git-index.md
@@ -144,8 +144,8 @@ Vim's built in `:diffget` and `:diffput` commands work a bit like `:Gread` and `
 * [`:help do`][do]
 * [`:help dp`][dp]
 
-[gi1]: http://book.git-scm.com/1_the_git_index.html
-[gi7]: http://book.git-scm.com/7_the_git_index.html
+[gi1]: http://schacon.github.io/gitbook/1_the_git_index.html
+[gi7]: http://schacon.github.io/gitbook/7_the_git_index.html
 [solarized]: http://ethanschoonover.com/solarized
 [dfp]: http://vimdoc.sourceforge.net/htmldoc/diff.html#:diffput
 [dp]: http://vimdoc.sourceforge.net/htmldoc/diff.html#dp

--- a/source/episodes/34-fugitive-vim-browsing-the-git-object-database.md
+++ b/source/episodes/34-fugitive-vim-browsing-the-git-object-database.md
@@ -12,7 +12,7 @@ With the fugitive plugin, you're not limited to just working with files in your 
 
 *This is the penultimate of a five part series on fugitive.vim.*
 
-[gito]: http://book.git-scm.com/1_the_git_object_model.html
+[gito]: http://schacon.github.io/gitbook/1_the_git_object_model.html
 
 
 READMORE
@@ -101,8 +101,8 @@ set statusline=%<%f\ %h%m%r%{fugitive#statusline()}%=%-14.(%l,%c%V%)\ %P
 * [`:help fugitive-mappings`][mappings]
 * [`:help fugitive-statusline`][statusline]
 
-[gito]: http://book.git-scm.com/1_the_git_object_model.html
-[gbr]: http://book.git-scm.com/7_browsing_git_objects.html
+[gito]: http://schacon.github.io/gitbook/1_the_git_object_model.html
+[gbr]: http://schacon.github.io/gitbook/7_browsing_git_objects.html
 [colonH]: http://vimdoc.sourceforge.net/htmldoc/cmdline.html#::h
 [percent]: http://vimdoc.sourceforge.net/htmldoc/cmdline.html#c_%
 [15]: /e/15


### PR DESCRIPTION
Git community book is now hosted at schacon.github.io/gitbook, as
git-scm.com replaced it with newer Pro Git book.
