### PR TITLE
Update Upcase links on landing page.

### DIFF
--- a/source/_self-promotion.html.erb
+++ b/source/_self-promotion.html.erb
@@ -41,13 +41,15 @@
   <h3>Learn to use Vim efficiently in your Ruby projects</h3>
   <div class="pro-screencasts">
     <p class="pitch">
-      In association with Thoughtbot, one of the most well respected Rails consultancies in the world, I've produced a series of screencasts on how to make navigating your Ruby projects with Vim ultra-efficient.
+      In association with thoughtbot, one of the most well respected Rails consultancies in the world, I've produced a series of screencasts on how to make navigating your Ruby projects with Vim ultra-efficient.
       Along the way, you’ll also learn how to make Ruby blocks a first-class text object in Vim.
       This lets you edit Ruby code at a higher level of abstraction.
-      <a href="https://learn.thoughtbot.com/products/21-navigating-ruby-files-with-vim">Available to buy from Thoughtbot.</a>.
+      <a href="https://thoughtbot.com/upcase/navigating-ruby-files-with-vim">Available to buy from thoughtbot.</a>.
     </p>
   </div>
   <div class="pro-screencasts-image">
-    <img src="/images/thoughtbot-robot-logo.png"/>
+    <a href="https://thoughtbot.com/upcase/navigating-ruby-files-with-vim">
+      <img src="/images/thoughtbot-robot-logo.png"/>
+    </a>
   </div>
 </div>

--- a/source/publications/index.html.erb
+++ b/source/publications/index.html.erb
@@ -49,7 +49,7 @@ title: Publications by Drew Neil
   </div>
   <div class="description">
     <p>
-      In 2013, Thoughtbot commissioned a set of screencasts on Vim for Ruby developers:
+      In 2013, thoughtbot commissioned a set of screencasts on Vim for Ruby developers:
     </p>
 
     <blockquote>
@@ -67,7 +67,7 @@ title: Publications by Drew Neil
     </blockquote>
 
     <p>
-      <a href="https://thoughtbot.com/upcase/navigating-ruby-files-with-vim">Get access by joining Thoughbot Upcase</a>
+      <a href="https://thoughtbot.com/upcase/navigating-ruby-files-with-vim">Get access by joining thoughbot Upcase</a>
     </p>
   </div>
   <div class="publications-image thoughtbot">


### PR DESCRIPTION
This updates the Upcase links on the root page, and also updates the capitalization of thoughtbot in a few places (for historical reasons, "thoughtbot" is never capitalized).